### PR TITLE
:rocket: Deployment script now uses CloudShell storage

### DIFF
--- a/Deployment/ARM/ARM-template.json
+++ b/Deployment/ARM/ARM-template.json
@@ -75,6 +75,9 @@
             "parameters":{
                 "userAssignedIdentities_ProvisionGenie_ManagedIdentity_name": {
                     "value": "[parameters('userAssignedIdentities_ProvisionGenie_ManagedIdentity_name')]"
+                },
+                "resourceLocation": {
+                    "value": "[parameters('resourceLocation')]"
                 }
             }
         }

--- a/Deployment/ARM/ProvisionGenie-ManagedIdentity.json
+++ b/Deployment/ARM/ProvisionGenie-ManagedIdentity.json
@@ -4,6 +4,9 @@
     "parameters": {
         "userAssignedIdentities_ProvisionGenie_ManagedIdentity_name": {
             "type": "string"
+        },
+        "resourceLocation": {
+            "type": "string"
         }
     },
     "functions": [],
@@ -13,7 +16,7 @@
             "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
             "apiVersion": "2018-11-30",
             "name": "[parameters('userAssignedIdentities_ProvisionGenie_ManagedIdentity_name')]",
-            "location": "westeurope"
+            "location": "[parameters('resourceLocation')]"
         }
     ],
     "outputs": {}

--- a/Deployment/Scripts/Deploy-Solution.ps1
+++ b/Deployment/Scripts/Deploy-Solution.ps1
@@ -5,19 +5,19 @@ param (
     $Location,
     [Parameter(Mandatory = $true)]
     [string]
-    $StorageAccountName,
-    [Parameter(Mandatory = $true)]
-    [string]
     $DataverseEnvironmentId,
     [Parameter(Mandatory = $true)]
     [string]
     $WelcomePackageUrl,
     [Parameter(Mandatory = $false)]
     [string]
-    $SubscriptionId = ""
+    $SubscriptionId = "",
+    [Parameter(Mandatory = $false)]
+    [string]
+    $ResourceGroupName = "ProvisionGenie"
 )
-
-$ResourceGroupName = "ProvisionGenie"
+# Stop processing if errors occur
+$ErrorActionPreference = "Stop"
 
 if ($SubscriptionId -ne "") {
     az account set -s $SubscriptionId
@@ -28,73 +28,85 @@ if ($SubscriptionId -ne "") {
     $SubscriptionName = $Subscription.name
     Write-Host "Active Subscription is $SubscriptionId ($SubscriptionName)"
 }
-# check the location provided is valid
+
+Write-Host "Validating deployment location"
 $ValidateLocation = az account list-locations --query "[?name=='$Location']" | ConvertFrom-Json
 if ($ValidateLocation.Count -eq 0) {
     Write-Error "The location provided is not valid, the available locations for your account are:"
     az account list-locations
     exit 1
 }
-Write-Host "Creating AzureAD application"
-$app = az ad app create --display-name ProvisionGenieApp --available-to-other-tenants false | ConvertFrom-Json
-$sp = az ad app credential reset --id $app.appId --append | ConvertFrom-Json
-az ad app permission add --id $app.appid --api 00000007-0000-0000-c000-000000000000 --api-permissions 78ce3f0f-a1ce-49c2-8cde-64b5c0896db4=Scope
-az ad sp create --id $app.appid
-az ad app permission grant --id $app.appid --api 00000007-0000-0000-c000-000000000000
-Write-Host "Creating Resource Groups"
+
+$driveInfo = Get-CloudDrive
+$StorageAccountName = $driveInfo.StorageAccountName
+$UrlBase = "https:" + $driveInfo.FileSharePath
+
+Write-Host "Validating current directory is in clouddrive"
+if (!$pwd.Path.StartsWith($driveInfo.MountPoint)) {
+    Write-Error "Please ensure that you cd into the clouddrive directory before cloning the project so that the ARM templates can be accessed with a SAS Token via a URL for deployment."
+    exit 1
+}
+
+Write-Host "Ensuring current user has contributor permissions to clouddrive storage account"
+# Ensure that the current user has the Contributor role for the storage account
+$me = az ad signed-in-user show | ConvertFrom-Json
+$StorageAccountId = az storage account show -g $driveInfo.ResourceGroupName -n $driveInfo.StorageAccountName --query id
+$roleAssignments = az role assignment list --all --assignee $me.objectId --query "[?scope=='$StorageAccountId' && roleDefinitionName=='Contributor'].roleDefinitionName" | ConvertFrom-Json
+if ($roleAssignments.Count -eq 0) {
+    Write-Host "Current user does not have contributor permissions to clouddrive storage account, attempting to assign contributor permissions"
+    az role assignment create --assignee $me.objectId --role contributor --scope $StorageAccountId
+}
+
+$appId = az ad app list --query "[?displayName=='ProvisionGenieApp'].appId | [0]"
+if ($null -eq $appId) {
+    Write-Host "Creating AzureAD application"
+    $app = az ad app create --display-name ProvisionGenieApp --available-to-other-tenants false | ConvertFrom-Json
+    $appId = $app.appId
+    Write-Host "Assigning AzureAD application permissions"
+    az ad app permission add --id $appid --api 00000007-0000-0000-c000-000000000000 --api-permissions 78ce3f0f-a1ce-49c2-8cde-64b5c0896db4=Scope
+    az ad sp create --id $appid
+    az ad app permission grant --id $appid --api 00000007-0000-0000-c000-000000000000
+} else {
+    Write-Host "Removing old client secrets from ProvisionGenieApp"
+    az ad app credential list --id $appId --query [].keyId | ConvertFrom-Json | ForEach-Object {
+        az ad app credential delete --id $appId --key-id $_
+    }
+}
+Write-Host "Generating ClientSecret for AzureAD application"
+$sp = az ad app credential reset --id $appId --append | ConvertFrom-Json
+
+Write-Host "Creating Resource Group"
 $MainResourceGroup = az group create `
     --name $ResourceGroupName `
     --location $Location
-$DeployResourceGroupName = $ResourceGroupName + "-deploy"
-$DeployResourceGroup = az group create `
-    --name $DeployResourceGroupName `
-    --location $Location
 
-Write-Host "Creating storage account $StorageAccountName"
-$StorageAccount = az storage account create `
-    --name $StorageAccountName `
-    --resource-group $DeployResourceGroupName `
-    --location $Location `
-    --sku Standard_LRS | ConvertFrom-Json
 Write-Host "Getting access key for storage account $StorageAccountName"
 $Key = az storage account keys list `
     --account-name $StorageAccountName `
-    --resource-group $DeployResourceGroupName `
+    --resource-group $driveInfo.ResourceGroupName `
     --query "[0].value"
-
-$DeployContainerName = "templates"
-Write-Host "Creating storage container $DeployContainerName in $StorageAccountName"
-$Container = az storage container create `
-    --name $DeployContainerName `
-    --account-name $StorageAccountName `
-    --auth-mode login
 
 # Set up an expriy for the SAS Token
 $Expiry = (Get-Date).AddHours(1).ToUniversalTime().ToString("yyyy-MM-dTH:mZ")
-Write-Host "Setting SAS Token for container expiring at $Expiry"
-$SasToken = az storage container generate-sas `
-    --name $DeployContainerName `
+Write-Host "Creating read-only SAS Token for container expiring at $Expiry"
+$SasToken = az storage account generate-sas `
     --account-name $StorageAccountName `
     --https-only `
-    --permissions cr `
+    --permissions r `
+    --services f `
+    --resource-types o `
     --expiry $Expiry `
     --account-key $Key
-# use Join-Path to build the path so that this works on both Linux and Windows
-$TemplatePath = Join-Path ".." "ARM"
-Write-Host "Uploading templates at $TemplatePath to $DeployContainerName in $StorageAccountName"
-az storage blob upload-batch `
-    --destination $DeployContainerName `
-    --source $TemplatePath `
-    --account-name $StorageAccountName `
-    --sas-token $SasToken
 
-$mainTemplateUri = $StorageAccount.primaryEndpoints.blob + "$DeployContainerName/ARM-template.json"
+$ArmTemplateFolderUrl = $pwd.Path.Replace($driveInfo.MountPoint, $UrlBase).Replace("Scripts", "ARM")
+$MainTemplateUri = $armTemplateFolderUrl + "/ARM-template.json"
+
 $DeployTimestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMdTHmZ")
 # Deploy
 az deployment group create `
   --name "DeployLinkedTemplate-$DeployTimestamp" `
   --resource-group $ResourceGroupName `
-  --template-uri $mainTemplateUri `
+  --template-uri $MainTemplateUri `
   --query-string $SasToken `
   --parameters subscriptionId=$SubscriptionId `
                 DataverseEnvironmentId=$DataverseEnvironmentId `
@@ -111,6 +123,13 @@ Write-Host "Azure Logic Apps deployed, granting permissions to ProvisionGenie-Ma
 $ManagedIdentity = az identity show --name ProvisionGenie-ManagedIdentity --resource-group $ResourceGroupName | ConvertFrom-Json
 
 $principalId = $ManagedIdentity.principalId
+# Get current role assignments
+$currentRoles = (az rest `
+    --method get `
+    --uri https://graph.microsoft.com/v1.0/servicePrincipals/$principalId/appRoleAssignments `
+    | ConvertFrom-Json).value `
+    | ForEach-Object { $_.appRoleId }
+
 $graphResourceId = az ad sp list --display-name "Microsoft Graph" --query [0].objectId
 #Get appRoleIds for Team.Create, Group.ReadWrite.All, Directory.ReadWrite.All, Group.Create, Sites.Manage.All, Sites.ReadWrite.All
 $graphId = az ad sp list --query "[?appDisplayName=='Microsoft Graph'].appId | [0]" --all
@@ -123,13 +142,16 @@ $sitesReadWriteAll = az ad sp show --id $graphId --query "appRoles[?value=='Site
 $appRoleIds = $teamCreate, $readWriteAll, $directoryReadWriteAll, $groupCreate, $sitesManageAll, $sitesReadWriteAll
 #Loop over all appRoleIds
 foreach ($appRoleId in $appRoleIds) {
-    # Add the role assignment ot the principal
-    $body = "{'principalId':'$principalId','resourceId':'$graphResourceId','appRoleId':'$appRoleId'}";
-    az rest `
-        --method post `
-        --uri https://graph.microsoft.com/v1.0/servicePrincipals/$principalId/appRoleAssignments `
-        --body $body `
-        --headers Content-Type=application/json 
+    $roleMatch = $currentRoles -match $appRoleId
+    if ($roleMatch.Length -eq 0) {
+        # Add the role assignment to the principal
+        $body = "{'principalId':'$principalId','resourceId':'$graphResourceId','appRoleId':'$appRoleId'}";
+        az rest `
+            --method post `
+            --uri https://graph.microsoft.com/v1.0/servicePrincipals/$principalId/appRoleAssignments `
+            --body $body `
+            --headers Content-Type=application/json 
+    }
 }
 
 Write-Host "Done"

--- a/Docs/docs/deploymentguide/2-deployazureresources.md
+++ b/Docs/docs/deploymentguide/2-deployazureresources.md
@@ -1,6 +1,6 @@
 # 2. Deploy Azure resources
 
-The scripted deployment will create two resource groups, by default these are `ProvisionGenie` and `ProvisionGenie-deploy`.
+The scripted deployment will create a new resource group, by default this is named `ProvisionGenie`.
 
 In the `ProvisionGenie-deploy` the script will create a new storage account, with the name that is supplied. A SAS Token with create and read permissions is created and used to upload the ARM template files into a container within the storage account. Then the ARM template deployment is started.
 
@@ -8,18 +8,17 @@ In the `ProvisionGenie-deploy` the script will create a new storage account, wit
 
 - Open Azure cloud shell at [shell.azure.com]
 > This guide assumes the use of a PowerShell environment.
+- Change the current directory to the clouddrive folder so that the ARM templates can be read from the attached Azure File Share `cd clouddrive`
 - Clone the git repository to Azure Cloud Shell `git clone https://github.com/ProvisionGenie/ProvisionGenie.git`
 - Change the working directory to the `ProvisionGenie/Deployment/Scripts` folder
     - `cd ./ProvisionGenie/Deployment/Scripts`
 - Execute the script `./Deploy-Solution.ps1` and supply the following parameters:
+    > If you want to supply a custom resource group name or deploy to a different subscription you may provide those as parameters when running the script `./Deploy-Solution.ps1 -ResourceGroupName MyResourceGroup -SubscriptionId "00000000-0000-0000-0000-000000000000"`
     - `Location` the Azure region to deploy into, e.g. westeurope
-    - `StorageAccountName` the name of the storage account to create, this must be globally unique
     - `DataverseEnvironmentId` You obtained this from Dataverse as **Instance URL**
     - `WelcomePackageUrl` the URL for learning material (if you don't know that for now, you can put `https://m365princess.com` or any other URL into it)
-- The script will run and deploy the Azure resources and then prompt you to supply:
-    - the App ID from your Azure AD app registration
-    - the App secret from your Azure AD app registration
-    - the Tenant ID from you Azure AD app registration
+    $ResourceGroupName = "ProvisionGenie"
+- The script will run and deploy the Azure resources
 
 ## Validate deployment
 

--- a/Docs/next/cli-instructions.md
+++ b/Docs/next/cli-instructions.md
@@ -105,13 +105,13 @@ Deploy-Solution.ps1`
 
 The Azure region that the resources are to be deployed in.
 
-`-StorageAccountName`
-
-The name of the storage account used to hold the ARM templates for deploying ProvisionGenie. This must be globally unique.
-
 `-DataverseEnvironmentId`
 
 The Id of the Dataverse environment hosting the database tables
+
+`WelcomePackageUrl`
+
+The url of the welcome package to be used e.g. `https://m365princess.com`
 
 ### Optional Parameters
 
@@ -124,6 +124,3 @@ The name of the Resource Group to be created to contain the ProvisionGenie Logic
 > Default value: The current default subscription for the Azure CLI environment
 
 The Id of the Azure Subscription to deploy into.
-
-`WelcomePackageUrl`
-> Default value: [https://m365princess.com](https://m365princess.com)


### PR DESCRIPTION
Deployment script now reads ARM templates from storage account sitting under CloudShell
User is assigned Contributor role to CloudShell storage account if they do not already have it
Removed deployment resource group and storage account creation from script
Update role assignment to Managed Identity to ensure roles are only added if needed
Updated deployment documentation to match changes
Added optional parameter for ResourceGroupName
Fixed Managed Identity having fixed deployment location of westeurope

