### PR TITLE
:rocket: Revert to use separate storage account

### DIFF
--- a/Deployment/Scripts/Deploy-Solution.ps1
+++ b/Deployment/Scripts/Deploy-Solution.ps1
@@ -5,6 +5,9 @@ param (
     $Location,
     [Parameter(Mandatory = $true)]
     [string]
+    $StorageAccountName,
+    [Parameter(Mandatory = $true)]
+    [string]
     $DataverseEnvironmentId,
     [Parameter(Mandatory = $true)]
     [string]
@@ -14,13 +17,18 @@ param (
     $SubscriptionId = "",
     [Parameter(Mandatory = $false)]
     [string]
-    $ResourceGroupName = "ProvisionGenie"
+    $ResourceGroupName = "ProvisionGenie",
+    [Parameter(Mandatory = $false)]
+    [string]
+    $AadAppName = "ProvisionGenieApp"
 )
-# Stop processing if errors occur
-$ErrorActionPreference = "Stop"
 
 if ($SubscriptionId -ne "") {
     az account set -s $SubscriptionId
+    if (!$?) { 
+        Write-Error "Unable to select $SubscriptionId as the active subscription."
+        exit 1
+    }
     Write-Host "Active Subscription set to $SubscriptionId"
 } else {
     $Subscription = az account show | ConvertFrom-Json
@@ -33,41 +41,21 @@ Write-Host "Validating deployment location"
 $ValidateLocation = az account list-locations --query "[?name=='$Location']" | ConvertFrom-Json
 if ($ValidateLocation.Count -eq 0) {
     Write-Error "The location provided is not valid, the available locations for your account are:"
-    az account list-locations
+    az account list-locations --query [].name
     exit 1
 }
 
-$driveInfo = Get-CloudDrive
-$StorageAccountName = $driveInfo.StorageAccountName
-$UrlBase = "https:" + $driveInfo.FileSharePath
-
-Write-Host "Validating current directory is in clouddrive"
-if (!$pwd.Path.StartsWith($driveInfo.MountPoint)) {
-    Write-Error "Please ensure that you cd into the clouddrive directory before cloning the project so that the ARM templates can be accessed with a SAS Token via a URL for deployment."
-    exit 1
-}
-
-Write-Host "Ensuring current user has contributor permissions to clouddrive storage account"
-# Ensure that the current user has the Contributor role for the storage account
-$me = az ad signed-in-user show | ConvertFrom-Json
-$StorageAccountId = az storage account show -g $driveInfo.ResourceGroupName -n $driveInfo.StorageAccountName --query id
-$roleAssignments = az role assignment list --all --assignee $me.objectId --query "[?scope=='$StorageAccountId' && roleDefinitionName=='Contributor'].roleDefinitionName" | ConvertFrom-Json
-if ($roleAssignments.Count -eq 0) {
-    Write-Host "Current user does not have contributor permissions to clouddrive storage account, attempting to assign contributor permissions"
-    az role assignment create --assignee $me.objectId --role contributor --scope $StorageAccountId
-}
-
-$appId = az ad app list --query "[?displayName=='ProvisionGenieApp'].appId | [0]"
+$appId = az ad app list --query "[?displayName=='$AadAppName'].appId | [0]"
 if ($null -eq $appId) {
     Write-Host "Creating AzureAD application"
-    $app = az ad app create --display-name ProvisionGenieApp --available-to-other-tenants false | ConvertFrom-Json
+    $app = az ad app create --display-name $AadAppName --available-to-other-tenants false | ConvertFrom-Json
     $appId = $app.appId
     Write-Host "Assigning AzureAD application permissions"
     az ad app permission add --id $appid --api 00000007-0000-0000-c000-000000000000 --api-permissions 78ce3f0f-a1ce-49c2-8cde-64b5c0896db4=Scope
     az ad sp create --id $appid
     az ad app permission grant --id $appid --api 00000007-0000-0000-c000-000000000000
 } else {
-    Write-Host "Removing old client secrets from ProvisionGenieApp"
+    Write-Host "Removing old client secrets from $AadAppName"
     az ad app credential list --id $appId --query [].keyId | ConvertFrom-Json | ForEach-Object {
         az ad app credential delete --id $appId --key-id $_
     }
@@ -80,42 +68,80 @@ $MainResourceGroup = az group create `
     --name $ResourceGroupName `
     --location $Location
 
+Write-Host "Ensuring current user has contributor permissions to $ResourceGroupName resource group"
+
+$me = az ad signed-in-user show | ConvertFrom-Json
+$roleAssignments = az role assignment list --all --assignee $me.objectId --query "[?resourceGroup=='$ResourceGroupName' && roleDefinitionName=='Contributor'].roleDefinitionName" | ConvertFrom-Json
+if ($roleAssignments.Count -eq 0) {
+    Write-Host "Current user does not have contributor permissions to $ResourceGroupName resource group, attempting to assign contributor permissions"
+    az role assignment create --assignee $me.objectId --role contributor --resource-group $ResourceGroupName
+}
+
+Write-Host "Creating storage account $StorageAccountName"
+$StorageAccount = az storage account create `
+    --name $StorageAccountName `
+    --resource-group $ResourceGroupName `
+    --location $Location `
+    --sku Standard_LRS | ConvertFrom-Json
+if (!$?) { 
+    Write-Error "Unable to create storage account $StorageAccountName."
+    exit 1
+}
 Write-Host "Getting access key for storage account $StorageAccountName"
 $Key = az storage account keys list `
     --account-name $StorageAccountName `
-    --resource-group $driveInfo.ResourceGroupName `
+    --resource-group $ResourceGroupName `
     --query "[0].value"
+
+$DeployContainerName = "templates"
+Write-Host "Creating storage container $DeployContainerName in $StorageAccountName"
+$Container = az storage container create `
+    --name $DeployContainerName `
+    --account-name $StorageAccountName `
+    --auth-mode login
 
 # Set up an expriy for the SAS Token
 $Expiry = (Get-Date).AddHours(1).ToUniversalTime().ToString("yyyy-MM-dTH:mZ")
-Write-Host "Creating read-only SAS Token for container expiring at $Expiry"
-$SasToken = az storage account generate-sas `
+Write-Host "Setting SAS Token for container expiring at $Expiry"
+$SasToken = az storage container generate-sas `
+    --name $DeployContainerName `
     --account-name $StorageAccountName `
     --https-only `
-    --permissions r `
-    --services f `
-    --resource-types o `
+    --permissions crw `
     --expiry $Expiry `
     --account-key $Key
 
-$ArmTemplateFolderUrl = $pwd.Path.Replace($driveInfo.MountPoint, $UrlBase).Replace("Scripts", "ARM")
-$MainTemplateUri = $armTemplateFolderUrl + "/ARM-template.json"
+# use Join-Path to build the path so that this works on both Linux and Windows
+$TemplatePath = Join-Path ".." "ARM"
+Write-Host "Uploading templates at $TemplatePath to $DeployContainerName in $StorageAccountName"
+az storage blob upload-batch `
+    --destination $DeployContainerName `
+    --source $TemplatePath `
+    --account-name $StorageAccountName `
+    --sas-token $SasToken
+
+$MainTemplateUri = $StorageAccount.primaryEndpoints.blob + "$DeployContainerName/ARM-template.json"
 
 $DeployTimestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMdTHmZ")
 # Deploy
 az deployment group create `
-  --name "DeployLinkedTemplate-$DeployTimestamp" `
-  --resource-group $ResourceGroupName `
-  --template-uri $MainTemplateUri `
-  --query-string $SasToken `
-  --parameters subscriptionId=$SubscriptionId `
+    --name "DeployLinkedTemplate-$DeployTimestamp" `
+    --resource-group $ResourceGroupName `
+    --template-uri $MainTemplateUri `
+    --query-string $SasToken `
+    --parameters subscriptionId=$SubscriptionId `
                 DataverseEnvironmentId=$DataverseEnvironmentId `
                 resourceGroupName=$ResourceGroupName `
                 WelcomePackageUrl=$WelcomePackageUrl `
                 servicePrincipal_AppId=$sp.appId `
                 servicePrincipal_ClientSecret=$sp.clientSecret `
                 servicePrincipal_TenantId=$sp.tenantId `
-  --verbose
+    --verbose
+
+if (!$?) { 
+    Write-Error "An error occured during the ARM deployment."
+    exit 1
+}
 
 Write-Host "Azure Logic Apps deployed, granting permissions to ProvisionGenie-ManagedIdentity"
 
@@ -133,12 +159,12 @@ $currentRoles = (az rest `
 $graphResourceId = az ad sp list --display-name "Microsoft Graph" --query [0].objectId
 #Get appRoleIds for Team.Create, Group.ReadWrite.All, Directory.ReadWrite.All, Group.Create, Sites.Manage.All, Sites.ReadWrite.All
 $graphId = az ad sp list --query "[?appDisplayName=='Microsoft Graph'].appId | [0]" --all
-$teamCreate = az ad sp show --id $graphId --query "appRoles[?value=='Team.Create'].id | [0]"
-$readWriteAll = az ad sp show --id $graphId --query "appRoles[?value=='Group.ReadWrite.All'].id | [0]"
-$directoryReadWriteAll = az ad sp show --id $graphId --query "appRoles[?value=='Directory.ReadWrite.All'].id | [0]"
-$groupCreate = az ad sp show --id $graphId --query "appRoles[?value=='Group.Create'].id | [0]"
-$sitesManageAll = az ad sp show --id $graphId --query "appRoles[?value=='Sites.Manage.All'].id | [0]"
-$sitesReadWriteAll = az ad sp show --id $graphId --query "appRoles[?value=='Sites.ReadWrite.All'].id | [0]"
+$teamCreate = az ad sp show --id $graphId --query "appRoles[?value=='Team.Create'].id | [0]" -o tsv
+$readWriteAll = az ad sp show --id $graphId --query "appRoles[?value=='Group.ReadWrite.All'].id | [0]" -o tsv
+$directoryReadWriteAll = az ad sp show --id $graphId --query "appRoles[?value=='Directory.ReadWrite.All'].id | [0]" -o tsv
+$groupCreate = az ad sp show --id $graphId --query "appRoles[?value=='Group.Create'].id | [0]" -o tsv
+$sitesManageAll = az ad sp show --id $graphId --query "appRoles[?value=='Sites.Manage.All'].id | [0]" -o tsv
+$sitesReadWriteAll = az ad sp show --id $graphId --query "appRoles[?value=='Sites.ReadWrite.All'].id | [0]" -o tsv
 $appRoleIds = $teamCreate, $readWriteAll, $directoryReadWriteAll, $groupCreate, $sitesManageAll, $sitesReadWriteAll
 #Loop over all appRoleIds
 foreach ($appRoleId in $appRoleIds) {

--- a/Docs/docs/deploymentguide/2-deployazureresources.md
+++ b/Docs/docs/deploymentguide/2-deployazureresources.md
@@ -2,19 +2,19 @@
 
 The scripted deployment will create a new resource group, by default this is named `ProvisionGenie`.
 
-In the `ProvisionGenie-deploy` the script will create a new storage account, with the name that is supplied. A SAS Token with create and read permissions is created and used to upload the ARM template files into a container within the storage account. Then the ARM template deployment is started.
+The script will create a new storage account, with the name that is supplied. A SAS Token with create, read, and write permissions is created and used to upload the ARM template files into a container within the storage account. Then the ARM template deployment is started.
 
 ## Deploy using the script
 
 - Open Azure cloud shell at [shell.azure.com]
 > This guide assumes the use of a PowerShell environment.
-- Change the current directory to the clouddrive folder so that the ARM templates can be read from the attached Azure File Share `cd clouddrive`
 - Clone the git repository to Azure Cloud Shell `git clone https://github.com/ProvisionGenie/ProvisionGenie.git`
 - Change the working directory to the `ProvisionGenie/Deployment/Scripts` folder
     - `cd ./ProvisionGenie/Deployment/Scripts`
 - Execute the script `./Deploy-Solution.ps1` and supply the following parameters:
-    > If you want to supply a custom resource group name or deploy to a different subscription you may provide those as parameters when running the script `./Deploy-Solution.ps1 -ResourceGroupName MyResourceGroup -SubscriptionId "00000000-0000-0000-0000-000000000000"`
+    > If you want to supply a custom resource group name, AAD App Registration Name, or deploy to a different subscription you may provide those as parameters when running the script `./Deploy-Solution.ps1 -ResourceGroupName MyResourceGroup -SubscriptionId "00000000-0000-0000-0000-000000000000" -AadAppName MyCustomAadAppName`
     - `Location` the Azure region to deploy into, e.g. westeurope
+    - `StorageAccountName` the name of the storage account to create, this must be globally unique
     - `DataverseEnvironmentId` You obtained this from Dataverse as **Instance URL**
     - `WelcomePackageUrl` the URL for learning material (if you don't know that for now, you can put `https://m365princess.com` or any other URL into it)
     $ResourceGroupName = "ProvisionGenie"

--- a/Docs/next/cli-instructions.md
+++ b/Docs/next/cli-instructions.md
@@ -105,6 +105,10 @@ Deploy-Solution.ps1`
 
 The Azure region that the resources are to be deployed in.
 
+`-StorageAccountName`
+
+The name of the storage account used to hold the ARM templates for deploying ProvisionGenie. This must be globally unique.
+
 `-DataverseEnvironmentId`
 
 The Id of the Dataverse environment hosting the database tables
@@ -124,3 +128,8 @@ The name of the Resource Group to be created to contain the ProvisionGenie Logic
 > Default value: The current default subscription for the Azure CLI environment
 
 The Id of the Azure Subscription to deploy into.
+
+`-AadAppName`
+> Default value: ProvisionGenieApp
+
+The name of the AAD App Registration to be created to authenticate against Dataverse.


### PR DESCRIPTION
Returns to provisioning a storage account to hold the ARM templates
Fixes permission checking
Adds optional parameter for name of the AAD App Registration
Successfully fails if the supplied SubscriptionId cannot be set as the active subscription
Adds better error handling to crucial cli calls
